### PR TITLE
Comprehensive update: use PSR12, PHPCompatibility, add Readme, add QA

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.gitattributes export-ignore
+.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
+/.github export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,0 +1,61 @@
+name: QA
+
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - master
+  # Allow manually triggering the workflow.
+  workflow_dispatch:
+
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  # The concurrency group contains the workflow name and the branch name.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: 'Basic QA checks'
+    runs-on: ubuntu-latest
+
+    env:
+      XMLLINT_INDENT: '    '
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.0'
+          coverage: none
+          tools: cs2pr
+
+      # Validate the composer.json file.
+      # @link https://getcomposer.org/doc/03-cli.md#validate
+      - name: Validate Composer installation
+        run: composer validate --no-check-all --strict
+
+      # Verify the package can be installed succesfully.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v1
+
+      - name: Install xmllint
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+
+      # Show XML violations inline in the file diff.
+      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
+      - uses: korelstar/xmllint-problem-matcher@v1
+
+      # Validate the ruleset XML file.
+      # @link http://xmlsoft.org/xmllint.html
+      - name: Validate ruleset against XML schema
+        run: xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./PHPParallelLint/ruleset.xml
+
+      # Check the code-style consistency of the XML ruleset files.
+      - name: Check XML ruleset code style
+        run: diff -B --tabsize=4 ./PHPParallelLint/ruleset.xml <(xmllint --format "./PHPParallelLint/ruleset.xml")

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+composer.lock

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
-<ruleset name="Jakub Onderka Coding Standard">
-    <description>A coding standard for Jakub Onderka's projects.</description>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHPParallelLint" xsi:noNamespaceSchemaLocation="../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <description>A coding standard for projects in the PHP Parallel Lint organisation.</description>
 
     <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
     <rule ref="PEAR.Functions.FunctionDeclaration"/>

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -33,6 +33,20 @@
 
     <!--
     #############################################################################
+    SNIFF FOR PHP CROSS-VERSION COMPATIBILITY
+    https://github.com/PHPCompatibility/PHPCompatibility/
+
+    It is STRONGLY recommended for individual projects to set a `testVersion`
+    config indicating which PHP versions should be supported.
+    https://github.com/PHPCompatibility/PHPCompatibility/#using-a-custom-ruleset
+    #############################################################################
+    -->
+
+    <rule ref="PHPCompatibility"/>
+
+
+    <!--
+    #############################################################################
     MISCELLANEOUS ADDITIONAL RULES
     #############################################################################
     -->

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -30,32 +30,12 @@
     #############################################################################
     -->
 
-    <rule ref="PEAR.Functions.FunctionDeclaration"/>
-    <rule ref="PEAR.Functions.FunctionCallSignature"/>
-    <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.CloseBracketLine">
-        <severity>0</severity>
-    </rule>
-    <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
-        <severity>0</severity>
-    </rule>
-
     <rule ref="Generic.PHP.NoSilencedErrors"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
 
     <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-
-    <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
-
-    <rule ref="PEAR.Classes.ClassDeclaration"/>
-
-    <rule ref="PEAR.ControlStructures.ControlSignature"/>
-
-    <rule ref="Zend.Files.ClosingTag"/>
 
     <rule ref="Generic.NamingConventions.ConstructorName"/>
 

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -3,7 +3,33 @@
 
     <description>A coding standard for projects in the PHP Parallel Lint organisation.</description>
 
-    <rule ref="Generic.Functions.FunctionCallArgumentSpacing"/>
+    <!--
+    #############################################################################
+    CHECK CODE STYLE AGAINST PSR12
+    https://www.php-fig.org/psr/psr-12/
+    #############################################################################
+    -->
+    <rule ref="PSR12">
+        <!-- Constant visibility is a PHP 7.1 feature and cannot (yet) be used. -->
+        <exclude name="PSR12.Properties.ConstantVisibility"/>
+    </rule>
+
+    <!-- ## Sniff specific configuration for sniffs included in PSR12 ## -->
+
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="125"/>
+            <property name="absoluteLineLimit" value="200"/>
+        </properties>
+    </rule>
+
+
+    <!--
+    #############################################################################
+    MISCELLANEOUS ADDITIONAL RULES
+    #############################################################################
+    -->
+
     <rule ref="PEAR.Functions.FunctionDeclaration"/>
     <rule ref="PEAR.Functions.FunctionCallSignature"/>
     <rule ref="PEAR.Functions.FunctionCallSignature.Indent">
@@ -15,10 +41,7 @@
     <rule ref="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket">
         <severity>0</severity>
     </rule>
-    <rule ref="PEAR.Functions.ValidDefaultValue"/>
 
-    <rule ref="Generic.PHP.DisallowShortOpenTag"/>
-    <rule ref="Generic.PHP.LowerCaseConstant"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
@@ -26,24 +49,15 @@
 
     <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
 
-    <rule ref="Generic.WhiteSpace.DisallowTabIndent"/>
     <rule ref="PEAR.WhiteSpace.ScopeClosingBrace"/>
 
     <rule ref="PEAR.Classes.ClassDeclaration"/>
 
-    <rule ref="Generic.ControlStructures.InlineControlStructure"/>
     <rule ref="PEAR.ControlStructures.ControlSignature"/>
 
-    <rule ref="Generic.Files.LineLength">
-        <properties>
-            <property name="lineLimit" value="125"/>
-            <property name="absoluteLineLimit" value="200"/>
-        </properties>
-    </rule>
     <rule ref="Zend.Files.ClosingTag"/>
 
     <rule ref="Generic.NamingConventions.ConstructorName"/>
-    <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
     <rule ref="Generic.Metrics.NestingLevel"/>
     <rule ref="Generic.Metrics.CyclomaticComplexity"/>

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -30,24 +30,26 @@
     #############################################################################
     -->
 
+    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+
+    <rule ref="Generic.Formatting.SpaceAfterCast"/>
+
+    <rule ref="Generic.Metrics.CyclomaticComplexity"/>
+    <rule ref="Generic.Metrics.NestingLevel"/>
+
+    <rule ref="Generic.NamingConventions.ConstructorName"/>
+
     <rule ref="Generic.PHP.NoSilencedErrors"/>
+
+    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
+
+    <rule ref="PEAR.Commenting.InlineComment"/>
+
+    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
+
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
 
-    <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
-
-    <rule ref="Generic.NamingConventions.ConstructorName"/>
-
-    <rule ref="Generic.Metrics.NestingLevel"/>
-    <rule ref="Generic.Metrics.CyclomaticComplexity"/>
-
-    <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
-    <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
-
-    <rule ref="PEAR.Commenting.InlineComment"/>
-
-    <rule ref="Generic.Formatting.SpaceAfterCast"/>
-
-    <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 </ruleset>

--- a/PHPParallelLint/ruleset.xml
+++ b/PHPParallelLint/ruleset.xml
@@ -23,6 +23,13 @@
         </properties>
     </rule>
 
+    <rule ref="PSR12.ControlStructures.BooleanOperatorPlacement">
+        <properties>
+            <!-- Only allow them at the start of the line. -->
+            <property name="allowOnly" value="first"/>
+        </properties>
+    </rule>
+
 
     <!--
     #############################################################################
@@ -30,8 +37,17 @@
     #############################################################################
     -->
 
+    <rule ref="Generic.Arrays.ArrayIndent"/>
+
     <rule ref="Generic.CodeAnalysis.EmptyStatement"/>
+    <rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
+    <rule ref="Generic.CodeAnalysis.ForLoopShouldBeWhileLoop"/>
+    <rule ref="Generic.CodeAnalysis.JumbledIncrementer"/>
+    <rule ref="Generic.CodeAnalysis.UnconditionalIfStatement"/>
+    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>
     <rule ref="Generic.CodeAnalysis.UselessOverridingMethod"/>
+
+    <rule ref="Generic.ControlStructures.DisallowYodaConditions"/>
 
     <rule ref="Generic.Formatting.SpaceAfterCast"/>
 
@@ -40,6 +56,7 @@
 
     <rule ref="Generic.NamingConventions.ConstructorName"/>
 
+    <rule ref="Generic.PHP.ForbiddenFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
 
     <rule ref="Generic.Strings.UnnecessaryStringConcat"/>
@@ -51,5 +68,7 @@
     <rule ref="Squiz.PHP.GlobalKeyword"/>
     <rule ref="Squiz.PHP.LowercasePHPFunctions"/>
     <rule ref="Squiz.PHP.NonExecutableCode"/>
+
+    <rule ref="Squiz.WhiteSpace.SemicolonSpacing"/>
 
 </ruleset>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+PHP Code Style
+=================
+
+Basic, PSR-12 based, coding standard for use by projects in the PHP Parallel Lint GitHub organisation.
+
+## Installation
+
+Install this standard via Composer:
+
+```bash
+composer require --dev php-parallel-lint/php-code-style
+```
+
+## Using the standard
+
+Once installed for a project, use this standard via the command-line:
+```bash
+vendor/bin/phpcs . --standard=PHPParallelLint
+```
+
+Or use the standard in a project specific PHPCS ruleset:
+```xml
+<?xml version="1.0"?>
+<ruleset name="Project Name">
+
+    <rule ref="PHPParallelLint"/>
+
+</ruleset>
+```

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     },
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "phpcompatibility/php-compatibility": "^9.3",
         "squizlabs/php_codesniffer": "^3.6.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "php-parallel-lint/php-code-style",
-    "version": "1.0",
+    "description": "PHP_CodeSniffer rules for projects in the PHP Parallel Lint organisation",
     "type": "library",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,9 @@
     ],
     "replace": {
         "jakub-onderka/php-code-style": "*"
+    },
+    "require": {
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+        "squizlabs/php_codesniffer": "^3.6.1"
     }
 }


### PR DESCRIPTION
### Ruleset: allow for usage as a standard

In contrast to plain ruleset, a PHPCS "standard" can:
* Be registered with PHPCS and used by name, both on the command line as well as in custom rulesets.
* Contain custom sniffs, if so desired.

For a ruleset to be recognized as a standard by PHPCS, it should:
* Live in a folder which matches the name of the standard
* That folder must contain a `ruleset.xml` file.

By moving the `ruleset.xml` file to a `PHPParallelLint` folder and changing the name of the standard to `PHPParallelLint`, this ruleset should now be usable as a standard.

Includes updating the description to match the current reality.

### Make the PHPCS standard self-contained

As things were, this package contained a ruleset, but did not declare its dependency on PHP_CodeSniffer, so the package would not be usable without the dependant declaring a dependency on PHPCS.

This commit fixes this by:
1. Declaring PHPCS as a dependency in the `composer.json` file.
2. Declaring a dependency on the DealerDirect Composer plugin which can automatically handle the registration of PHPCS standards with PHPCS.

With these two dependencies in place, the package can be used as a self-contained package.

Includes adding a `.gitignore` file to prevent the `composer.lock` and `vendor` directory from being committed, as well as a `.gitattributes` file to prevent the `.gitignore` (and `.gitattributes`) file from being included in distributed packages.

### GH Actions: add a basic QA workflow

This workflow will check that:
* The `composer.json` is valid.
* The declared dependencies install without problems.
* The PHPCS ruleset validates against the XML scheme for PHPCS rulesets.
* The PHPCS ruleset is consistent in code-style.

Includes adding the `.github` directory to the `.gitattributes` file to be excluded from distribution packages.

### Ruleset: check code style against PSR12 

This commit:
* Adds the complete PSR12 ruleset to this standard.
* Excludes one PSR12 sniff which requires a higher minimum PHP version (PHP 7.1), than the projects in the organisation support.
* Removes any individual sniff inclusions for sniffs also included in PSR12.
    This can be verified by running the following command which shows exactly which sniffs are included in PSR12:
    ```bash
    vendor/bin/phpcs --standard=PSR12 -e
    ```

### Ruleset: remove more redundant rules

* The `PEAR.Functions.FunctionDeclaration` sniff can be removed as the PSR12 standard contains the following sniffs which together provide the same safeguards and more: `Squiz.Functions.FunctionDeclaration` and `Squiz.Functions.MultiLineFunctionDeclaration`
* The `PEAR.Functions.FunctionCallSignature` sniff can be removed as the PSR12 standard contains the semi-equivalent `PSR2.Methods.FunctionCallSignature` sniff.
    Note: I'm also removing the exclusions from the standard. IMO, the standard should not have an opinion on this. A custom ruleset for an individual project can bring these exclusions back if/when needed.
* The `PEAR.WhiteSpace.ScopeClosingBrace` sniff can be removed as the PSR12 standard contains the semi-equivalent `Squiz.WhiteSpace.ScopeClosingBrace` sniff.
* The `PEAR.Classes.ClassDeclaration` sniff can be removed as the PSR12 standard contains the more comprehensive `PSR2.Classes.ClassDeclaration` sniff.
* The `PEAR.ControlStructures.ControlSignature` sniff can be removed as the PSR12 standard contains the more comprehensive `Squiz.ControlStructures.ControlSignature` sniff.
* The `Zend.Files.ClosingTag` sniff can be removed as the PSR12 standard contains the semi-equivalent `PSR2.Files.ClosingTag` sniff.

### Ruleset: order remaining extra rules alphabetically

### Ruleset: add a few extra sniffs + a property for one of the PSR12 sniffs

* The `PSR12.ControlStructures.BooleanOperatorPlacement` sniffs checks for consistent placement of boolean operators in control structure conditions.
    The extra property enforces that these are always placed at the start of a line.
* PSR12 has no opinion on array formatting. The `Generic.Arrays.ArrayIndent` sniff will at least safeguard some semblance of normalized arrays.
* The `Generic.CodeAnalysis.EmptyPHPStatement` prevents empty PHP statements, like when there is a duplicate semi-colon at the end of a statement.
* The `Generic.ControlStructures.DisallowYodaConditions` ensures that conditions never use Yoda.
* Additionally, the `Generic.CodeAnalysis.ForLoopShouldBeWhileLoop`, `Generic.CodeAnalysis.JumbledIncrementer`, `Generic.CodeAnalysis.UnconditionalIfStatement`, `Generic.CodeAnalysis.UnnecessaryFinalModifier`, `Generic.PHP.ForbiddenFunctions` and the `Squiz.WhiteSpace.SemicolonSpacing` sniffs, which were already in use in the PHP Parallel Lint repo, but not in the other repos, have also been added.
    Note: the `Generic.PHP.DeprecatedFunctions` sniff, as used in the PHP Parallel Lint repo, has **not** been added as the PHPCompatibility standard included a far more comprehensive and stable sniff for the same.

### Composer/Ruleset: include the PHPCompatibility standard

The PHPCompatibility standard can detect a large range of PHP cross-version incompatibilities and flag these, to prevent code being committed to the projects which is incompatible with the minimum supported PHP version of those projects.

For optimal results, the projects using this standard should set a `testVersion` to inform PHPCompatibility which PHP versions the code should be compatible with.

For more information, see the README of the project.

Ref: https://github.com/PHPCompatibility/PHPCompatibility/

### Add a README

... with the most basic information about the coding standard.

### Composer: minor tweaks

* Add a `description`, so the `composer.json` will validate.
* Remove the `version` key as recommended by Composer.