### PR TITLE
GH Actions: update the xmllint-problem-matcher

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -51,7 +51,7 @@ jobs:
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - uses: korelstar/xmllint-problem-matcher@v1
+      - uses: korelstar/xmllint-problem-matcher@v1.1
 
       # Validate the ruleset XML file.
       # @link http://xmlsoft.org/xmllint.html


### PR DESCRIPTION
The `xmllint-problem-matcher` action runner has released a new version which updates it to use node 16. This gets rid of a warning which was shown in the action logs.

Refs:
* https://github.com/korelstar/xmllint-problem-matcher/releases/tag/v1.1