### PR TITLE
GH Actions: use the xmllint-validate action runner

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -47,26 +47,14 @@ jobs:
           # Bust the cache at least once a month - output format: YYYY-MM.
           custom-cache-suffix: $(date -u "+%Y-%m")
 
-      # Updating the lists can fail intermittently, typically after Microsoft has released a new package.
-      # This should not be blocking for this job, so ignore any errors from this step.
-      # Ref: https://github.com/dotnet/core/issues/4167
-      - name: Update the available packages list
-        continue-on-error: true
-        run: sudo apt-get update
+      # Validate the xml file.
+      - name: Validate against schema
+        uses: phpcsstandards/xmllint-validate@v1
+        with:
+          pattern: "PHPParallelLint/ruleset.xml"
+          xsd-file: "vendor/squizlabs/php_codesniffer/phpcs.xsd"
 
-      - name: Install xmllint
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
-
-      # Show XML violations inline in the file diff.
-      # @link https://github.com/marketplace/actions/xmllint-problem-matcher
-      - name: Enable showing XML issues inline
-        uses: korelstar/xmllint-problem-matcher@v1
-
-      # Validate the ruleset XML file.
-      # @link http://xmlsoft.org/xmllint.html
-      - name: Validate ruleset against XML schema
-        run: xmllint --noout --schema ./vendor/squizlabs/php_codesniffer/phpcs.xsd ./PHPParallelLint/ruleset.xml
-
-      # Check the code-style consistency of the XML ruleset files.
+      # Check the code-style consistency of the XML ruleset file.
+      # Note: this needs xmllint, but that will be installed via the phpcsstandards/xmllint-validate action runner in the previous step.
       - name: Check XML ruleset code style
         run: diff -B --tabsize=4 ./PHPParallelLint/ruleset.xml <(xmllint --format "./PHPParallelLint/ruleset.xml")


### PR DESCRIPTION
Instead of doing all the installation steps for xmllint validation in the workflow, use the :sparkles: new dedicated `phpcsstandards/xmllint-validate` action runner instead.

Ref: https://github.com/marketplace/actions/xmllint-validate