### PR TITLE
Composer: update version requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,11 @@
     },
     "require": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-        "phpcompatibility/php-compatibility": "^9.3",
-        "squizlabs/php_codesniffer": "^3.9.0"
+        "phpcompatibility/php-compatibility": "^10.0.0@dev",
+        "squizlabs/php_codesniffer": "^3.13.4"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true


### PR DESCRIPTION
... deliberately not upgrading to PHPCS 4.0 yet as that has a minimum PHP requirement of PHP 7.2, while the PHP-Parallel-Lint packages still support older PHP versions, so updating to PHPCS 4.0 would complicate CI.